### PR TITLE
Add basic mode system

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,6 +20,18 @@ body {
   overflow: visible;
 }
 
+.sandbox-active {
+  filter: grayscale(0.6);
+}
+
+.review-active {
+  filter: brightness(1.1);
+}
+
+.custom-active {
+  filter: sepia(0.2);
+}
+
 .row {
   display: flex;
   flex: 1;


### PR DESCRIPTION
## Summary
- add new `mode` state and boards for sandbox, review and custom setups
- add handlers for sandbox, review, custom clicks
- add UI buttons to switch modes
- gray out board in sandbox and tweak styles for other modes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684398d07300832f908c83535dbdee1b